### PR TITLE
Fix special cases for downloads

### DIFF
--- a/pkg/pkgproxy/proxy.go
+++ b/pkg/pkgproxy/proxy.go
@@ -264,10 +264,10 @@ func (pp *pkgProxy) ForwardProxy(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 		}
 		clientResp.WriteHeader(rsp.StatusCode)
-		if rsp.ContentLength > 0 {
+		bodyBytes, _ := io.ReadAll(rsp.Body)
+		if len(bodyBytes) > 0 {
 			// ignore errors, since there's nothing we can do
-			bodyBytes, _ := io.ReadAll(rsp.Body)
-			size, _ := io.CopyN(clientResp.Writer, bytes.NewReader(bodyBytes), rsp.ContentLength)
+			size, _ := io.CopyN(clientResp.Writer, bytes.NewReader(bodyBytes), int64(len(bodyBytes)))
 			clientResp.Size = size
 		}
 

--- a/pkg/pkgproxy/proxy.go
+++ b/pkg/pkgproxy/proxy.go
@@ -64,6 +64,7 @@ var (
 		"Authorization",
 		"Cache-Control",
 		"Cookie",
+		"Range",
 		"Referer",
 		"User-Agent",
 	}


### PR DESCRIPTION
* Don't depend on `Content-Length` header. I guess it could also be possible that an upstream server sends its response with `Transfer-Encoding: chunked`
* Forward `Range` header sent by client. The [zchunk](https://fedoraproject.org/wiki/Changes/Zchunk_Metadata) download mechanism used by Fedora uses this to only download partial metadata files.