### PR TITLE
github-workflows: Fix go version lookup on publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Fix issue with action that fails with:
  Error: The specified go version file at: go.mod does not exist