### PR TITLE
Makefile: Generate kodata/pkgproxy.yaml at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bin/
 /cache/
 image-ref.out
+/kodata/pkgproxy.yaml
 
 # local openspec setup
 package.json

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,9 @@ image-build: ## Build container image with ko
 	$(info ***********************************************************)
 	$(info ********** EXECUTING 'image-build' MAKE TARGET ************)
 	$(info ***********************************************************)
+	trap 'rm -f kodata/pkgproxy.yaml' EXIT; \
+	mkdir -p kodata; \
+	cp configs/pkgproxy.yaml kodata/pkgproxy.yaml; \
 	KO_DOCKER_REPO=$${KO_DOCKER_REPO:-ko.local} \
 	KO_DATA_DATE_EPOCH=$$(git log -1 --format='%ct') \
 	VERSION=$(VERSION) \

--- a/kodata/pkgproxy.yaml
+++ b/kodata/pkgproxy.yaml
@@ -1,1 +1,0 @@
-../configs/pkgproxy.yaml


### PR DESCRIPTION
Stop tracking the bundled config in git; copy it from configs/ into kodata/ before the ko image build and remove it afterwards, so the container image config stays in sync with configs/pkgproxy.yaml.